### PR TITLE
Add ad-hoc signing for macOS builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,18 @@ jobs:
         fi
       shell: bash
     
+    # Ad-hoc sign macOS app to prevent "damaged app" error
+    - name: Ad-hoc Sign macOS App
+      if: matrix.os == 'macos-latest'
+      run: |
+        echo "Cleaning extended attributes from Weld.app..."
+        xattr -cr build/bin/Weld.app
+        echo "Ad-hoc signing Weld.app..."
+        codesign --force --deep --sign - build/bin/Weld.app
+        echo "Verifying signature..."
+        codesign --verify --verbose build/bin/Weld.app
+      shell: bash
+    
     # Package the build
     - name: Package Build
       run: |


### PR DESCRIPTION
## Summary
Add ad-hoc code signing to macOS builds to prevent the "damaged app" error.

## Changes
- Add codesign step to release workflow
- Clean extended attributes before signing
- Verify signature after signing

## Testing
- Tested locally with: `codesign --force --deep --sign - /path/to/Weld.app`
- Signature verification passes

Fixes #4

🤖 Generated with [Claude Code](https://claude.ai/code)