### PR TITLE
fix: resolve Biome warnings and UI issues

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -36,11 +36,7 @@ import { handleKeydown as handleKeyboardShortcut } from "./utils/keyboard.js";
 import { getLanguageFromExtension } from "./utils/language.js";
 // biome-ignore lint/correctness/noUnusedImports: Used in Svelte template
 import { getDisplayPath } from "./utils/path.js";
-import {
-	calculateScrollToCenterLine,
-	clampScrollPosition,
-	createScrollSynchronizer,
-} from "./utils/scrollSync.js";
+import { createScrollSynchronizer } from "./utils/scrollSync.js";
 
 // Shiki highlighter instance
 // biome-ignore lint/suspicious/noExplicitAny: Highlighter is disabled and set to null
@@ -217,9 +213,9 @@ let lineChunks: LineChunk[] = [];
 const viewportTop = 0;
 // biome-ignore lint/correctness/noUnusedVariables: Used in Minimap component
 const viewportHeight = 0;
-let isDraggingViewport = false;
-const dragStartY = 0;
-const dragStartScrollTop = 0;
+let _isDraggingViewport = false;
+const _dragStartY = 0;
+const _dragStartScrollTop = 0;
 
 // Minimap visibility state
 let _showMinimap = true;
@@ -1062,7 +1058,7 @@ function _handleViewportDrag(event: MouseEvent): void {
 
 function _handleViewportMouseUp(): void {
 	// TODO: This functionality needs to be moved to DiffViewer component
-	isDraggingViewport = false;
+	_isDraggingViewport = false;
 }
 
 function playInvalidSound(): void {
@@ -1138,15 +1134,16 @@ function jumpToPrevDiff(): void {
 	scrollToLine(chunk.startIndex);
 }
 
+// biome-ignore lint/suspicious/noExplicitAny: Svelte component ref
 let diffViewerComponent: any;
 
 function scrollToLine(lineIndex: number): void {
-	if (diffViewerComponent && diffViewerComponent.scrollToLine) {
+	if (diffViewerComponent?.scrollToLine) {
 		diffViewerComponent.scrollToLine(lineIndex);
 	}
 }
 
-function handleChunkClick(event: {
+function _handleChunkClick(event: {
 	chunkIndex: number;
 	lineIndex: number;
 }): void {
@@ -1458,42 +1455,6 @@ function checkHorizontalScrollbar() {
     border-bottom-color: #363a4f;
   }
 
-  :global([data-theme="dark"]) .file-btn {
-    background: #363a4f;
-    border-color: #5b6078;
-    color: #cad3f5;
-  }
-
-  :global([data-theme="dark"]) .file-btn:hover {
-    background: #414559;
-  }
-
-  :global([data-theme="dark"]) .file-icon {
-    background: transparent;
-    border-right-color: #5b6078;
-  }
-
-  :global([data-theme="dark"]) .file-btn:hover .file-icon {
-    background: transparent;
-  }
-
-  :global([data-theme="dark"]) .compare-btn {
-    background: #8aadf4;
-    border-color: #8aadf4;
-    color: #24273a;
-  }
-
-  :global([data-theme="dark"]) .compare-btn:hover:not(:disabled) {
-    background: #7dc4e4;
-  }
-
-  :global([data-theme="dark"]) .compare-btn:disabled {
-    background: #5b6078;
-    border-color: #5b6078;
-    color: #a5adcb;
-    opacity: 0.7;
-  }
-
   :global([data-theme="dark"]) .file-header {
     background: #1e2030;
   }
@@ -1655,85 +1616,6 @@ function checkHorizontalScrollbar() {
     color: #333;
   }
 
-  .file-selectors {
-    display: flex;
-    gap: 1rem;
-    margin-bottom: 0.5rem;
-  }
-
-  .file-btn {
-    display: flex;
-    align-items: stretch;
-    padding: 0;
-    border: 1px solid #acb0be;
-    border-radius: 4px;
-    background: #dce0e8;
-    cursor: pointer;
-    font-size: 0.9rem;
-    width: auto;
-    height: 42px;
-    text-align: left;
-    color: #4c4f69;
-    overflow: hidden;
-  }
-
-  .file-btn:hover {
-    background: #ccd0da;
-  }
-
-  .file-icon {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0 0.6rem;
-    height: 100%;
-    background: transparent;
-    border-right: 1px solid #acb0be;
-    min-width: 32px;
-  }
-
-  .file-btn:hover .file-icon {
-    background: transparent;
-  }
-
-  .file-icon :global(svg) {
-    width: 20px;
-    height: 20px;
-  }
-
-  .file-name {
-    padding: 0 0.75rem;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    display: flex;
-    align-items: center;
-    width: 200px;
-  }
-
-  .compare-btn {
-    padding: 0.5rem 1rem;
-    border: 1px solid #1e66f5;
-    border-radius: 4px;
-    background: #1e66f5;
-    color: #eff1f5;
-    cursor: pointer;
-    font-size: 0.9rem;
-    font-weight: 600;
-    min-width: 150px;
-    height: auto;
-  }
-
-  .compare-btn:hover:not(:disabled) {
-    background: #04a5e5;
-  }
-
-  .compare-btn:disabled {
-    background: #94a3b8;
-    border-color: #94a3b8;
-    cursor: not-allowed;
-    opacity: 0.7;
-  }
 
 
   .error {

--- a/frontend/src/components/DiffGutter.svelte
+++ b/frontend/src/components/DiffGutter.svelte
@@ -18,7 +18,7 @@ let gutterElement: HTMLElement;
 
 // Event dispatcher
 const dispatch = createEventDispatcher<{
-	scroll: void;
+	scroll: undefined;
 	copyLineToLeft: number;
 	copyLineToRight: number;
 	copyChunkToLeft: LineChunk;

--- a/frontend/src/components/DiffHeader.svelte
+++ b/frontend/src/components/DiffHeader.svelte
@@ -13,8 +13,8 @@ export let lineNumberWidth: string;
 
 // Event dispatcher
 const dispatch = createEventDispatcher<{
-	saveLeft: void;
-	saveRight: void;
+	saveLeft: undefined;
+	saveRight: undefined;
 }>();
 
 // Event handlers

--- a/frontend/src/components/DiffPane.svelte
+++ b/frontend/src/components/DiffPane.svelte
@@ -20,10 +20,10 @@ let paneElement: HTMLElement;
 
 // Event dispatcher
 const dispatch = createEventDispatcher<{
-	scroll: void;
+	scroll: undefined;
 	chunkClick: number;
 	chunkMouseEnter: number;
-	chunkMouseLeave: void;
+	chunkMouseLeave: undefined;
 }>();
 
 // Event handlers
@@ -32,7 +32,6 @@ function handleScroll(): void {
 	dispatch("scroll");
 }
 
-// biome-ignore lint/correctness/noUnusedVariables: Used in template
 function handleChunkClick(index: number): void {
 	const chunk = getChunkForLine(index);
 	if (chunk) {

--- a/frontend/src/components/DiffViewer.svelte
+++ b/frontend/src/components/DiffViewer.svelte
@@ -34,14 +34,15 @@ export let isSameFile: DiffViewerProps["isSameFile"];
 export let lineNumberWidth: DiffViewerProps["lineNumberWidth"];
 
 // Component refs for scroll synchronization
+// biome-ignore lint/suspicious/noExplicitAny: Svelte component refs
 let leftPaneComponent: any;
+// biome-ignore lint/suspicious/noExplicitAny: Svelte component refs
 let rightPaneComponent: any;
+// biome-ignore lint/suspicious/noExplicitAny: Svelte component refs
 let centerGutterComponent: any;
 
 // Viewport tracking for minimap
-// biome-ignore lint/correctness/noUnusedVariables: Used in Minimap component
 export let viewportTop = 0;
-// biome-ignore lint/correctness/noUnusedVariables: Used in Minimap component
 export let viewportHeight = 0;
 
 // Event dispatcher

--- a/frontend/src/components/FileSelector.svelte
+++ b/frontend/src/components/FileSelector.svelte
@@ -57,9 +57,9 @@ function handleCompareClick(): void {
   </button>
   <button class="compare-btn" on:click={handleCompareClick} disabled={!leftFilePath || !rightFilePath || isComparing || hasCompletedComparison}>
     {#if isComparing}
-      Comparing files...
+      Comparing...
     {:else}
-      Compare Files
+      Compare
     {/if}
   </button>
 </div>
@@ -69,6 +69,7 @@ function handleCompareClick(): void {
     display: flex;
     gap: 1rem;
     margin-bottom: 0.5rem;
+    align-items: center;
   }
 
   .file-btn {
@@ -124,7 +125,7 @@ function handleCompareClick(): void {
   }
 
   .compare-btn {
-    padding: 0.5rem 1rem;
+    padding: 0 1.5rem;
     border: 1px solid #1e66f5;
     border-radius: 4px;
     background: #1e66f5;
@@ -132,8 +133,8 @@ function handleCompareClick(): void {
     cursor: pointer;
     font-size: 0.9rem;
     font-weight: 600;
-    min-width: 150px;
-    height: auto;
+    min-width: 120px;
+    height: 42px;
     transition: background-color 0.2s ease;
   }
 

--- a/frontend/src/components/FileSelector.test.ts
+++ b/frontend/src/components/FileSelector.test.ts
@@ -30,7 +30,7 @@ describe("FileSelector", () => {
 
 		expect(getByText("Select left file...")).toBeInTheDocument();
 		expect(getByText("Select right file...")).toBeInTheDocument();
-		expect(getByText("Compare Files")).toBeInTheDocument();
+		expect(getByText("Compare")).toBeInTheDocument();
 	});
 
 	it("should display file names when provided", () => {
@@ -55,7 +55,7 @@ describe("FileSelector", () => {
 			},
 		});
 
-		const compareButton = getByText("Compare Files");
+		const compareButton = getByText("Compare");
 		expect(compareButton).toBeDisabled();
 	});
 
@@ -67,7 +67,7 @@ describe("FileSelector", () => {
 			},
 		});
 
-		const compareButton = getByText("Compare Files");
+		const compareButton = getByText("Compare");
 		expect(compareButton).not.toBeDisabled();
 	});
 
@@ -80,7 +80,7 @@ describe("FileSelector", () => {
 			},
 		});
 
-		expect(getByText("Comparing files...")).toBeInTheDocument();
+		expect(getByText("Comparing...")).toBeInTheDocument();
 	});
 
 	it("should disable compare button when comparison completed", () => {
@@ -92,13 +92,13 @@ describe("FileSelector", () => {
 			},
 		});
 
-		const compareButton = getByText("Compare Files");
+		const compareButton = getByText("Compare");
 		expect(compareButton).toBeDisabled();
 	});
 
 	it("should dispatch leftFileSelected event when left file selected", async () => {
 		const mockPath = "/path/to/selected.js";
-		(SelectFile as any).mockResolvedValue(mockPath);
+		vi.mocked(SelectFile).mockResolvedValue(mockPath);
 
 		const { getByText, component } = render(FileSelector);
 
@@ -118,7 +118,7 @@ describe("FileSelector", () => {
 
 	it("should dispatch rightFileSelected event when right file selected", async () => {
 		const mockPath = "/path/to/selected.py";
-		(SelectFile as any).mockResolvedValue(mockPath);
+		vi.mocked(SelectFile).mockResolvedValue(mockPath);
 
 		const { getByText, component } = render(FileSelector);
 
@@ -138,7 +138,7 @@ describe("FileSelector", () => {
 
 	it("should dispatch error event when file selection fails", async () => {
 		const mockError = new Error("File selection failed");
-		(SelectFile as any).mockRejectedValue(mockError);
+		vi.mocked(SelectFile).mockRejectedValue(mockError);
 
 		const { getByText, component } = render(FileSelector);
 
@@ -166,7 +166,7 @@ describe("FileSelector", () => {
 		const compareHandler = vi.fn();
 		component.$on("compare", compareHandler);
 
-		const compareButton = getByText("Compare Files");
+		const compareButton = getByText("Compare");
 		await fireEvent.click(compareButton);
 
 		expect(compareHandler).toHaveBeenCalled();

--- a/frontend/src/components/Minimap.svelte
+++ b/frontend/src/components/Minimap.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { createEventDispatcher } from "svelte";
-import type { LineChunk } from "../types";
+import type { LineChunk } from "../types/diff";
 
 // biome-ignore-start lint/style/useConst: Svelte component props must use 'let' for reactivity
 export let show: boolean = true;

--- a/frontend/src/components/Minimap.test.ts
+++ b/frontend/src/components/Minimap.test.ts
@@ -130,8 +130,9 @@ describe("Minimap", () => {
 		const mockHandler = vi.fn();
 		component.$on("minimapClick", mockHandler);
 
-		const minimap = container.querySelector(".minimap")!;
-		await fireEvent.click(minimap);
+		const minimap = container.querySelector(".minimap");
+		expect(minimap).toBeTruthy();
+		if (minimap) await fireEvent.click(minimap);
 
 		expect(mockHandler).toHaveBeenCalledTimes(1);
 		expect(mockHandler).toHaveBeenCalledWith(
@@ -155,8 +156,9 @@ describe("Minimap", () => {
 		const mockHandler = vi.fn();
 		component.$on("viewportMouseDown", mockHandler);
 
-		const viewport = container.querySelector(".minimap-viewport")!;
-		await fireEvent.mouseDown(viewport);
+		const viewport = container.querySelector(".minimap-viewport");
+		expect(viewport).toBeTruthy();
+		if (viewport) await fireEvent.mouseDown(viewport);
 
 		expect(mockHandler).toHaveBeenCalledTimes(1);
 		expect(mockHandler).toHaveBeenCalledWith(

--- a/frontend/src/types/diff.ts
+++ b/frontend/src/types/diff.ts
@@ -48,8 +48,8 @@ export interface DiffViewerProps {
 
 // Events emitted by DiffViewer
 export interface DiffViewerEvents {
-	saveLeft: void;
-	saveRight: void;
+	saveLeft: undefined;
+	saveRight: undefined;
 	copyLineToLeft: number; // line index
 	copyLineToRight: number; // line index
 	copyChunkToLeft: LineChunk;
@@ -60,8 +60,8 @@ export interface DiffViewerEvents {
 	deleteChunkFromRight: LineChunk;
 	chunkClick: number; // line index
 	chunkHover: number; // line index
-	chunkLeave: void;
-	scrollSync: void;
+	chunkLeave: undefined;
+	scrollSync: undefined;
 	minimapClick: MouseEvent;
 	viewportMouseDown: MouseEvent;
 }

--- a/frontend/src/utils/scrollSync.test.ts
+++ b/frontend/src/utils/scrollSync.test.ts
@@ -8,8 +8,8 @@ import {
 
 describe("scrollSync", () => {
 	let mockElements: ScrollElements;
-	let requestAnimationFrameSpy: any;
-	let setTimeoutSpy: any;
+	let requestAnimationFrameSpy: import("vitest").MockInstance;
+	let setTimeoutSpy: import("vitest").MockInstance;
 
 	beforeEach(() => {
 		// Mock DOM elements
@@ -45,9 +45,9 @@ describe("scrollSync", () => {
 		// Mock setTimeout
 		setTimeoutSpy = vi
 			.spyOn(window, "setTimeout")
-			.mockImplementation((cb: Function) => {
+			.mockImplementation((cb: () => void) => {
 				cb();
-				return 0 as any;
+				return 0 as unknown as ReturnType<typeof setTimeout>;
 			});
 	});
 
@@ -73,16 +73,18 @@ describe("scrollSync", () => {
 				syncer.setElements(mockElements);
 
 				// Set left pane scroll
-				mockElements.leftPane!.scrollTop = 100;
-				mockElements.leftPane!.scrollLeft = 50;
+				if (mockElements.leftPane) {
+					mockElements.leftPane.scrollTop = 100;
+					mockElements.leftPane.scrollLeft = 50;
+				}
 
 				// Sync
 				syncer.syncFromLeft();
 
 				// Check other panes were synced
-				expect(mockElements.rightPane!.scrollTop).toBe(100);
-				expect(mockElements.centerGutter!.scrollTop).toBe(100);
-				expect(mockElements.rightPane!.scrollLeft).toBe(50);
+				expect(mockElements.rightPane?.scrollTop).toBe(100);
+				expect(mockElements.centerGutter?.scrollTop).toBe(100);
+				expect(mockElements.rightPane?.scrollLeft).toBe(50);
 			});
 
 			it("should not sync if already syncing", () => {
@@ -90,22 +92,26 @@ describe("scrollSync", () => {
 				syncer.setElements(mockElements);
 				syncer.setSyncing(true);
 
-				mockElements.leftPane!.scrollTop = 100;
+				if (mockElements.leftPane) {
+					mockElements.leftPane.scrollTop = 100;
+				}
 				syncer.syncFromLeft();
 
 				// Should not have synced
-				expect(mockElements.rightPane!.scrollTop).toBe(0);
+				expect(mockElements.rightPane?.scrollTop).toBe(0);
 			});
 
 			it("should not sync during initial scroll", () => {
 				const syncer = createScrollSynchronizer();
 				syncer.setElements(mockElements);
 
-				mockElements.leftPane!.scrollTop = 100;
+				if (mockElements.leftPane) {
+					mockElements.leftPane.scrollTop = 100;
+				}
 				syncer.syncFromLeft({ isInitialScroll: true });
 
 				// Should not have synced
-				expect(mockElements.rightPane!.scrollTop).toBe(0);
+				expect(mockElements.rightPane?.scrollTop).toBe(0);
 			});
 
 			it("should call onSyncComplete callback", () => {
@@ -125,16 +131,18 @@ describe("scrollSync", () => {
 				syncer.setElements(mockElements);
 
 				// Set right pane scroll
-				mockElements.rightPane!.scrollTop = 200;
-				mockElements.rightPane!.scrollLeft = 75;
+				if (mockElements.rightPane) {
+					mockElements.rightPane.scrollTop = 200;
+					mockElements.rightPane.scrollLeft = 75;
+				}
 
 				// Sync
 				syncer.syncFromRight();
 
 				// Check other panes were synced
-				expect(mockElements.leftPane!.scrollTop).toBe(200);
-				expect(mockElements.centerGutter!.scrollTop).toBe(200);
-				expect(mockElements.leftPane!.scrollLeft).toBe(75);
+				expect(mockElements.leftPane?.scrollTop).toBe(200);
+				expect(mockElements.centerGutter?.scrollTop).toBe(200);
+				expect(mockElements.leftPane?.scrollLeft).toBe(75);
 			});
 		});
 
@@ -144,14 +152,16 @@ describe("scrollSync", () => {
 				syncer.setElements(mockElements);
 
 				// Set center gutter scroll
-				mockElements.centerGutter!.scrollTop = 300;
+				if (mockElements.centerGutter) {
+					mockElements.centerGutter.scrollTop = 300;
+				}
 
 				// Sync
 				syncer.syncFromCenter();
 
 				// Check content panes were synced
-				expect(mockElements.leftPane!.scrollTop).toBe(300);
-				expect(mockElements.rightPane!.scrollTop).toBe(300);
+				expect(mockElements.leftPane?.scrollTop).toBe(300);
+				expect(mockElements.rightPane?.scrollTop).toBe(300);
 			});
 
 			it("should use setTimeout for center sync", () => {
@@ -171,9 +181,9 @@ describe("scrollSync", () => {
 
 				await syncer.scrollToPosition(150);
 
-				expect(mockElements.leftPane!.scrollTop).toBe(150);
-				expect(mockElements.rightPane!.scrollTop).toBe(150);
-				expect(mockElements.centerGutter!.scrollTop).toBe(150);
+				expect(mockElements.leftPane?.scrollTop).toBe(150);
+				expect(mockElements.rightPane?.scrollTop).toBe(150);
+				expect(mockElements.centerGutter?.scrollTop).toBe(150);
 			});
 
 			it("should animate scroll when requested", async () => {
@@ -183,7 +193,7 @@ describe("scrollSync", () => {
 				await syncer.scrollToPosition(150, { animate: true });
 
 				expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(2);
-				expect(mockElements.leftPane!.scrollTop).toBe(150);
+				expect(mockElements.leftPane?.scrollTop).toBe(150);
 			});
 
 			it("should resolve even with missing elements", async () => {


### PR DESCRIPTION
## Summary

This PR addresses all Biome linter warnings and fixes several UI issues that emerged after the component extraction refactor.

## Changes

### Biome Linter Fixes
- Fixed all  type warnings by adding proper type annotations or suppression comments where needed
- Replaced  with  in event interface types (8 instances)
- Fixed non-null assertions in test files by adding proper null checks
- Removed ineffective suppression comments

### UI Fixes
- Removed duplicate FileSelector CSS from App.svelte that was causing styling conflicts
- Fixed FileSelector button text: "Compare Files" → "Compare"
- Fixed compare button height to match file selector buttons (42px)
- Fixed Minimap import path ( → )
- Updated all FileSelector tests to match new button text

## Test Results
- All 138 tests passing
- No Biome warnings remaining
- Frontend and backend code formatted

## Files Changed
- 11 files modified
- 77 insertions, 182 deletions (net reduction of 105 lines)