### PR TITLE
fix: center diff chunks in viewport when jumping

### DIFF
--- a/frontend/src/utils/scrollSync.test.ts
+++ b/frontend/src/utils/scrollSync.test.ts
@@ -224,18 +224,19 @@ describe("scrollSync", () => {
 			const lineHeight = 20;
 			const viewportHeight = 400;
 
-			// Line 10 should be at position 200, centered means scroll to 0
+			// Line 10: middle at position 210 (10*20 + 10), centered means scroll to 10
 			expect(calculateScrollToCenterLine(10, lineHeight, viewportHeight)).toBe(
-				0,
+				10,
 			);
 
-			// Line 50 should be at position 1000, centered means scroll to 800
+			// Line 50: middle at position 1010 (50*20 + 10), centered means scroll to 810
 			expect(calculateScrollToCenterLine(50, lineHeight, viewportHeight)).toBe(
-				800,
+				810,
 			);
 		});
 
 		it("should not return negative scroll values", () => {
+			// Line 5: middle at position 110 (5*20 + 10), centered would be -90, but clamped to 0
 			expect(calculateScrollToCenterLine(5, 20, 400)).toBe(0);
 		});
 	});

--- a/frontend/src/utils/scrollSync.ts
+++ b/frontend/src/utils/scrollSync.ts
@@ -190,9 +190,12 @@ export function calculateScrollToCenterLine(
 	lineHeight: number,
 	viewportHeight: number,
 ): number {
-	const linePosition = lineIndex * lineHeight;
+	// Calculate the position of the middle of the target line
+	const linePosition = lineIndex * lineHeight + lineHeight / 2;
 	const middleOfViewport = viewportHeight / 2;
-	return Math.max(0, linePosition - middleOfViewport);
+	// Calculate scroll position to center the line
+	const scrollPosition = linePosition - middleOfViewport;
+	return Math.max(0, scrollPosition);
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR fixes the jump-to-diff functionality to center diff chunks in the viewport, providing better context visibility when navigating between diffs.

## Problem

Previously, when jumping to a diff (via keyboard shortcuts, clicking chunks, or minimap), the diff would appear at the top of the viewport. This provided limited context, especially for multi-line diff chunks.

## Solution

- Updated `scrollToLine()` to detect if the target line is part of a diff chunk
- For diff chunks, calculate the middle line of the chunk and center that instead
- Updated `calculateScrollToCenterLine()` to properly account for line height when centering
- Added a small delay to ensure minimap viewport updates after scrolling

## Testing

- All existing tests pass
- Updated scroll sync tests to match new centering calculations
- Manually tested with various diff sizes and positions

## Result

Diffs now appear centered in the viewport, maximizing visible context both above and below the diff. This makes it easier to understand changes in their surrounding context.