### PR TITLE
feat: add macOS artifacts to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,10 +75,21 @@ jobs:
     - name: Build application
       run: wails build
     
+    # Ad-hoc sign macOS app to prevent "damaged app" error
+    - name: Ad-hoc Sign macOS App
+      if: matrix.os == 'macos-latest'
+      run: |
+        echo "Cleaning extended attributes from Weld.app..."
+        xattr -cr build/bin/Weld.app
+        echo "Ad-hoc signing Weld.app..."
+        codesign --force --deep --sign - build/bin/Weld.app
+        echo "Verifying signature..."
+        codesign --verify --verbose build/bin/Weld.app
+      shell: bash
+    
     # Upload artifacts (optional - for debugging)
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'windows-latest'
       with:
         name: weld-${{ matrix.os }}
         path: |


### PR DESCRIPTION
## Summary
- Added ad-hoc signing step for macOS builds in CI to prevent "damaged app" errors
- Removed platform restriction from artifact uploads so macOS builds are included
- Ensures all platforms (Windows, Linux, macOS) have CI artifacts available

## Context
Previously, CI artifacts were only being created for Windows and Linux builds. This was due to macOS builds requiring code signing to run properly. Since PR #5 added code signing to the release workflow, we can now apply the same ad-hoc signing approach to CI builds.

## Changes
- Added ad-hoc signing step that runs only for macOS builds
- Removed `if: matrix.platform \!= 'darwin'` condition from artifact upload step
- All three platforms now produce downloadable artifacts from CI runs

## Test plan
- CI workflow will run on this PR
- Verify macOS artifacts are created and uploaded
- Download and test macOS artifact to ensure it runs without "damaged app" error

🤖 Generated with [Claude Code](https://claude.ai/code)