### PR TITLE
refactor: centralize keyboard handling and add undo shortcuts

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -750,28 +750,26 @@ async function saveRightFile(): Promise<void> {
 }
 
 function handleKeydown(event: KeyboardEvent): void {
-	// Handle Shift+L and Shift+H for copying current diff
-	if (event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey) {
-		if (event.key === "L") {
-			event.preventDefault();
-			copyCurrentDiffLeftToRight();
-			return;
-		} else if (event.key === "H") {
-			event.preventDefault();
-			copyCurrentDiffRightToLeft();
-			return;
-		}
-	}
-
 	handleKeyboardShortcut(
 		event,
-		saveLeftFile,
-		saveRightFile,
+		{
+			saveLeftFile,
+			saveRightFile,
+			jumpToNextDiff,
+			jumpToPrevDiff,
+			copyCurrentDiffLeftToRight,
+			copyCurrentDiffRightToLeft,
+			undoLastChange,
+		},
 		leftFilePath,
 		rightFilePath,
-		jumpToNextDiff,
-		jumpToPrevDiff,
 	);
+}
+
+function undoLastChange(): void {
+	// TODO: Implement undo functionality
+	console.log("Undo functionality not yet implemented");
+	_errorMessage = "Undo functionality coming soon!";
 }
 
 async function _highlightFileContent(

--- a/frontend/src/utils.test.ts
+++ b/frontend/src/utils.test.ts
@@ -270,8 +270,10 @@ describe("Keyboard Utilities", () => {
 
 			handleKeydown(
 				mockEvent,
-				mockSaveLeftFile,
-				mockSaveRightFile,
+				{
+					saveLeftFile: mockSaveLeftFile,
+					saveRightFile: mockSaveRightFile,
+				},
 				leftFilePath,
 				rightFilePath,
 			);
@@ -303,8 +305,10 @@ describe("Keyboard Utilities", () => {
 
 			handleKeydown(
 				mockEvent,
-				mockSaveLeftFile,
-				mockSaveRightFile,
+				{
+					saveLeftFile: mockSaveLeftFile,
+					saveRightFile: mockSaveRightFile,
+				},
 				leftFilePath,
 				rightFilePath,
 			);
@@ -328,8 +332,10 @@ describe("Keyboard Utilities", () => {
 
 			handleKeydown(
 				mockEvent,
-				mockSaveLeftFile,
-				mockSaveRightFile,
+				{
+					saveLeftFile: mockSaveLeftFile,
+					saveRightFile: mockSaveRightFile,
+				},
 				"/path/left.txt",
 				"/path/right.txt",
 			);

--- a/frontend/src/utils/keyboard.ts
+++ b/frontend/src/utils/keyboard.ts
@@ -1,41 +1,78 @@
 /**
  * Keyboard event handling utilities
+ *
+ * Available keyboard shortcuts:
+ * - Cmd/Ctrl + S: Save both files
+ * - ArrowDown or j: Jump to next diff
+ * - ArrowUp or k: Jump to previous diff
+ * - Shift + L: Copy current diff from right to left
+ * - Shift + H: Copy current diff from left to right
+ * - Cmd/Ctrl + Z or u: Undo last change
  */
 
+export interface KeyboardHandlerCallbacks {
+	saveLeftFile: () => void;
+	saveRightFile: () => void;
+	jumpToNextDiff?: () => void;
+	jumpToPrevDiff?: () => void;
+	copyCurrentDiffLeftToRight?: () => void;
+	copyCurrentDiffRightToLeft?: () => void;
+	undoLastChange?: () => void;
+}
+
 /**
- * Handles keyboard shortcuts for save operations and navigation
+ * Handles all keyboard shortcuts for the application
  */
 export function handleKeydown(
 	event: KeyboardEvent,
-	saveLeftFile: () => void,
-	saveRightFile: () => void,
+	callbacks: KeyboardHandlerCallbacks,
 	leftPath: string,
 	rightPath: string,
-	jumpToNextDiff?: () => void,
-	jumpToPrevDiff?: () => void,
 ): void {
 	const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
 	const isCtrlOrCmd = isMac ? event.metaKey : event.ctrlKey;
 
+	// Handle Shift+L and Shift+H for copying current diff
+	if (event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey) {
+		if (event.key === "L" && callbacks.copyCurrentDiffLeftToRight) {
+			event.preventDefault();
+			callbacks.copyCurrentDiffLeftToRight();
+			return;
+		} else if (event.key === "H" && callbacks.copyCurrentDiffRightToLeft) {
+			event.preventDefault();
+			callbacks.copyCurrentDiffRightToLeft();
+			return;
+		}
+	}
+
+	// Save shortcuts
 	if (isCtrlOrCmd && event.key === "s") {
 		event.preventDefault();
 
 		if (leftPath) {
-			saveLeftFile();
+			callbacks.saveLeftFile();
 		}
 		if (rightPath) {
-			saveRightFile();
+			callbacks.saveRightFile();
 		}
 	}
 
 	// Navigation shortcuts: Arrow keys and vim keybindings
-	if (jumpToNextDiff && jumpToPrevDiff) {
+	if (callbacks.jumpToNextDiff && callbacks.jumpToPrevDiff) {
 		if (event.key === "ArrowDown" || event.key === "j") {
 			event.preventDefault();
-			jumpToNextDiff();
+			callbacks.jumpToNextDiff();
 		} else if (event.key === "ArrowUp" || event.key === "k") {
 			event.preventDefault();
-			jumpToPrevDiff();
+			callbacks.jumpToPrevDiff();
+		}
+	}
+
+	// Undo shortcuts: Cmd/Ctrl+Z or vim 'u' key
+	if (callbacks.undoLastChange) {
+		if ((isCtrlOrCmd && event.key === "z") || event.key === "u") {
+			event.preventDefault();
+			callbacks.undoLastChange();
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Centralized all keyboard handling logic in `utils/keyboard.ts`
- Added keyboard shortcuts for undo functionality (placeholder implementation)
- Improved code organization and maintainability

## Changes
1. **Refactored keyboard handling**:
   - Moved Shift+L/H shortcuts from App.svelte to keyboard.ts
   - Created `KeyboardHandlerCallbacks` interface for better type safety
   - All keyboard shortcuts now managed in one place

2. **Added undo shortcuts** (placeholder only):
   - Cmd/Ctrl+Z: Standard undo shortcut
   - 'u': Vim-style undo shortcut
   - **NOTE**: These shortcuts are wired up but the actual undo functionality is not implemented yet

## Available Keyboard Shortcuts
- Cmd/Ctrl + S: Save both files
- ArrowDown or j: Jump to next diff
- ArrowUp or k: Jump to previous diff
- Shift + L: Copy current diff from right to left
- Shift + H: Copy current diff from left to right
- Cmd/Ctrl + Z or u: Undo last change (placeholder - shows message)

## Next Steps
The actual undo functionality needs to be implemented in a separate PR. This will require:
- Creating a change history system
- Tracking diff operations
- Implementing undo/redo logic