### PR TITLE
fix: UI interaction bugs and minimap improvements

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1155,12 +1155,11 @@ function _handleChunkClick(event: {
 	chunkIndex: number;
 	lineIndex: number;
 }): void {
-	const { chunkIndex, lineIndex } = event;
+	const { chunkIndex } = event;
 
 	// Update the current diff chunk index
 	currentDiffChunkIndex = chunkIndex;
-	// Scroll to the line that was clicked
-	scrollToLine(lineIndex);
+	// Don't scroll - just highlight the chunk where it is
 }
 
 function _handleChunkMouseEnter(lineIndex: number): void {
@@ -1386,7 +1385,7 @@ function checkHorizontalScrollbar() {
     on:copyModifiedChunkToRight={(e) => _copyModifiedChunkToRight(e.detail)}
     on:deleteChunkFromLeft={(e) => _deleteChunkFromLeft(e.detail)}
     on:deleteChunkFromRight={(e) => _deleteChunkFromRight(e.detail)}
-    on:chunkClick={(e) => handleChunkClick(e.detail)}
+    on:chunkClick={(e) => _handleChunkClick(e.detail)}
     on:chunkHover={(e) => _handleChunkMouseEnter(e.detail)}
     on:chunkLeave={_handleChunkMouseLeave}
     on:minimapClick={(e) => _handleMinimapClick(e.detail)}

--- a/frontend/src/components/DiffViewer.svelte
+++ b/frontend/src/components/DiffViewer.svelte
@@ -426,7 +426,8 @@ $: if (
 				{viewportTop}
 				{viewportHeight}
 				{isDarkMode}
-				on:minimapClick={(e) => dispatch('minimapClick', e.detail.event)}
+				diffLines={diffResult?.lines || []}
+				on:minimapClick={(e) => dispatch('minimapClick', e.detail)}
 				on:viewportMouseDown={(e) => dispatch('viewportMouseDown', e.detail.event)}
 			/>
 		</div>

--- a/frontend/src/components/Minimap.test.ts
+++ b/frontend/src/components/Minimap.test.ts
@@ -138,7 +138,7 @@ describe("Minimap", () => {
 		expect(mockHandler).toHaveBeenCalledWith(
 			expect.objectContaining({
 				detail: expect.objectContaining({
-					event: expect.any(MouseEvent),
+					clickPercentage: expect.any(Number),
 				}),
 			}),
 		);


### PR DESCRIPTION
## Summary
- Fix chunk click handler naming mismatch
- Remove auto-scroll when clicking directly on chunks  
- Add tooltips to minimap chunks showing line ranges
- Fix minimap click navigation

## Bug Fixes

### Chunk Click Handler
- Fixed naming mismatch where event handler was calling `handleChunkClick` but function was named `_handleChunkClick`
- Removed auto-scroll behavior when clicking on chunks directly to reduce visual distraction

### Minimap Improvements
- Added tooltips showing line ranges when hovering over minimap chunks
- Different formats for added/removed/modified chunks:
  - Added: "Right: Lines X-Y" 
  - Removed: "Left: Lines X-Y"
  - Modified: "Left: X-Y, Right: X-Y"
- Fixed minimap click navigation to correctly identify and scroll to chunks
- Fixed UndoManager import issue (removed 'type' keyword)

## Known Issues
- Tooltips may not display consistently (needs further investigation)

## Test plan
- [x] All existing tests pass
- [x] Manual testing of chunk clicking
- [x] Manual testing of minimap navigation
- [x] Manual testing of tooltip display