### PR TITLE
feat: add comprehensive app menu updates

### DIFF
--- a/MANUAL_TEST_SCRIPT.md
+++ b/MANUAL_TEST_SCRIPT.md
@@ -248,6 +248,28 @@ Based on our automated testing gaps, pay special attention to:
 
 ---
 
+## 7. Go Menu Testing
+
+### Previous/Next Diff Navigation
+1. Compare two files with multiple differences
+2. Verify Go menu exists with Previous Diff and Next Diff options
+3. Test Previous Diff:
+   - Initially disabled when no diff is selected
+   - Press `k` key or use Go > Previous Diff
+   - Navigates to previous difference
+   - Shows notification sound when at first diff
+   - Menu item disabled when at first diff
+4. Test Next Diff:
+   - Initially enabled when at first diff
+   - Press `j` key or use Go > Next Diff
+   - Navigates to next difference
+   - Shows notification sound when at last diff
+   - Menu item disabled when at last diff
+5. Test state updates:
+   - After each navigation, menu items update enable/disable state
+   - Current diff is highlighted in UI
+   - Minimap shows current position
+
 ## Post-Refactoring Verification
 
 After any significant refactoring, run through this entire script to ensure:

--- a/MANUAL_TEST_SCRIPT.md
+++ b/MANUAL_TEST_SCRIPT.md
@@ -138,6 +138,26 @@ This script covers functionality that our automated integration tests cannot ver
   - [ ] Layout adjusts properly
   - [ ] Setting persists after restart
 
+### Test: File > Save Menu Items
+- [ ] Load two different files and compare
+- [ ] Verify File > Save submenu shows with all items disabled
+- [ ] Make changes via copy operation (Shift+L)
+- [ ] Verify File > Save > Save Right Pane enables
+- [ ] Click Save Right Pane - verify file saves and menu item disables
+- [ ] Make changes to both files
+- [ ] Verify Save Left Pane, Save Right Pane, and Save All enable
+- [ ] Test keyboard shortcuts:
+  - [ ] Cmd/Ctrl+S for Save All (saves both files if they have changes)
+
+### Test: Edit > Discard All Changes Menu Item
+- [ ] Make changes to both files
+- [ ] Verify Edit > Discard All Changes enables
+- [ ] Click Discard All Changes - verify:
+  - [ ] All changes are discarded
+  - [ ] Files reload from disk
+  - [ ] Menu item disables
+  - [ ] Save menu items all disable
+
 ---
 
 ## 6. Quit Dialog & Session Management

--- a/app.go
+++ b/app.go
@@ -72,6 +72,8 @@ type App struct {
 	saveLeftMenuItem  *menu.MenuItem
 	saveRightMenuItem *menu.MenuItem
 	saveAllMenuItem   *menu.MenuItem
+	prevDiffMenuItem  *menu.MenuItem
+	nextDiffMenuItem  *menu.MenuItem
 }
 
 // NewApp creates a new App application struct
@@ -683,6 +685,16 @@ func (a *App) SetSaveAllMenuItem(item *menu.MenuItem) {
 	a.saveAllMenuItem = item
 }
 
+// SetPrevDiffMenuItem stores a reference to the previous diff menu item
+func (a *App) SetPrevDiffMenuItem(item *menu.MenuItem) {
+	a.prevDiffMenuItem = item
+}
+
+// SetNextDiffMenuItem stores a reference to the next diff menu item
+func (a *App) SetNextDiffMenuItem(item *menu.MenuItem) {
+	a.nextDiffMenuItem = item
+}
+
 // UpdateSaveMenuItems updates the state of all save-related menu items
 func (a *App) UpdateSaveMenuItems(hasUnsavedLeft, hasUnsavedRight bool) {
 	// Update individual save items
@@ -703,6 +715,17 @@ func (a *App) UpdateSaveMenuItems(hasUnsavedLeft, hasUnsavedRight bool) {
 		a.discardMenuItem.Disabled = !hasUnsavedLeft && !hasUnsavedRight
 	}
 
+	runtime.MenuUpdateApplicationMenu(a.ctx)
+}
+
+// UpdateDiffNavigationMenuItems updates the state of the diff navigation menu items
+func (a *App) UpdateDiffNavigationMenuItems(hasPrevDiff, hasNextDiff bool) {
+	if a.prevDiffMenuItem != nil {
+		a.prevDiffMenuItem.Disabled = !hasPrevDiff
+	}
+	if a.nextDiffMenuItem != nil {
+		a.nextDiffMenuItem.Disabled = !hasNextDiff
+	}
 	runtime.MenuUpdateApplicationMenu(a.ctx)
 }
 

--- a/app.go
+++ b/app.go
@@ -62,12 +62,16 @@ var (
 
 // App struct
 type App struct {
-	ctx              context.Context
-	InitialLeftFile  string
-	InitialRightFile string
-	minimapVisible   bool
-	minimapMenuItem  *menu.MenuItem
-	undoMenuItem     *menu.MenuItem
+	ctx               context.Context
+	InitialLeftFile   string
+	InitialRightFile  string
+	minimapVisible    bool
+	minimapMenuItem   *menu.MenuItem
+	undoMenuItem      *menu.MenuItem
+	discardMenuItem   *menu.MenuItem
+	saveLeftMenuItem  *menu.MenuItem
+	saveRightMenuItem *menu.MenuItem
+	saveAllMenuItem   *menu.MenuItem
 }
 
 // NewApp creates a new App application struct
@@ -657,6 +661,49 @@ func (a *App) SetMinimapMenuItem(item *menu.MenuItem) {
 // SetUndoMenuItem stores a reference to the undo menu item
 func (a *App) SetUndoMenuItem(item *menu.MenuItem) {
 	a.undoMenuItem = item
+}
+
+// SetDiscardMenuItem stores a reference to the discard menu item
+func (a *App) SetDiscardMenuItem(item *menu.MenuItem) {
+	a.discardMenuItem = item
+}
+
+// SetSaveLeftMenuItem stores a reference to the save left menu item
+func (a *App) SetSaveLeftMenuItem(item *menu.MenuItem) {
+	a.saveLeftMenuItem = item
+}
+
+// SetSaveRightMenuItem stores a reference to the save right menu item
+func (a *App) SetSaveRightMenuItem(item *menu.MenuItem) {
+	a.saveRightMenuItem = item
+}
+
+// SetSaveAllMenuItem stores a reference to the save all menu item
+func (a *App) SetSaveAllMenuItem(item *menu.MenuItem) {
+	a.saveAllMenuItem = item
+}
+
+// UpdateSaveMenuItems updates the state of all save-related menu items
+func (a *App) UpdateSaveMenuItems(hasUnsavedLeft, hasUnsavedRight bool) {
+	// Update individual save items
+	if a.saveLeftMenuItem != nil {
+		a.saveLeftMenuItem.Disabled = !hasUnsavedLeft
+	}
+	if a.saveRightMenuItem != nil {
+		a.saveRightMenuItem.Disabled = !hasUnsavedRight
+	}
+
+	// Update save all - enabled if either side has unsaved changes
+	if a.saveAllMenuItem != nil {
+		a.saveAllMenuItem.Disabled = !hasUnsavedLeft && !hasUnsavedRight
+	}
+
+	// Update discard all - same logic as save all
+	if a.discardMenuItem != nil {
+		a.discardMenuItem.Disabled = !hasUnsavedLeft && !hasUnsavedRight
+	}
+
+	runtime.MenuUpdateApplicationMenu(a.ctx)
 }
 
 // BeginOperationGroup starts a new operation group for transaction-like undo

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -9,6 +9,7 @@ import {
 	QuitWithoutSaving,
 	SaveChanges,
 	SaveSelectedFilesAndQuit,
+	UpdateDiffNavigationMenuItems,
 	UpdateSaveMenuItems,
 } from "../wailsjs/go/main/App.js";
 import { EventsOn } from "../wailsjs/runtime/runtime.js";
@@ -166,6 +167,14 @@ $: diffChunks = (() => {
 
 	return chunks;
 })();
+
+// Update diff navigation menu items whenever diff state changes
+$: {
+	const hasPrevDiff = diffChunks.length > 0 && currentDiffChunkIndex > 0;
+	const hasNextDiff =
+		diffChunks.length > 0 && currentDiffChunkIndex < diffChunks.length - 1;
+	UpdateDiffNavigationMenuItems(hasPrevDiff, hasNextDiff);
+}
 
 $: isSameFile = leftFilePath && rightFilePath && leftFilePath === rightFilePath;
 
@@ -1286,6 +1295,8 @@ onMount(async () => {
 		}
 	});
 	EventsOn("menu-discard-all", _handleDiscardChanges);
+	EventsOn("menu-prev-diff", jumpToPrevDiff);
+	EventsOn("menu-next-diff", jumpToNextDiff);
 
 	// Check for initial files from command line
 	try {

--- a/frontend/src/components/DiffViewer.test.ts
+++ b/frontend/src/components/DiffViewer.test.ts
@@ -1,4 +1,4 @@
-import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import { fireEvent, render } from "@testing-library/svelte";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom";
 import type { DiffViewerProps, HighlightedDiffLine } from "../types/diff";

--- a/frontend/src/components/UndoManager.test.ts
+++ b/frontend/src/components/UndoManager.test.ts
@@ -3,10 +3,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import UndoManager from "./UndoManager.svelte";
 
 // Mock the Wails runtime
-const mockEventHandlers = new Map<string, Function>();
+const mockEventHandlers = new Map<string, () => void>();
 
 vi.mock("../../wailsjs/runtime/runtime", () => ({
-	EventsOn: vi.fn((event: string, handler: Function) => {
+	EventsOn: vi.fn((event: string, handler: () => void) => {
 		mockEventHandlers.set(event, handler);
 	}),
 	EventsOff: vi.fn((event: string) => {
@@ -26,7 +26,6 @@ import {
 	GetLastOperationDescription,
 	UndoLastOperation,
 } from "../../wailsjs/go/main/App";
-import { EventsOff, EventsOn } from "../../wailsjs/runtime/runtime";
 
 describe("UndoManager", () => {
 	beforeEach(() => {

--- a/frontend/src/tests/integration/copy-operations.test.ts
+++ b/frontend/src/tests/integration/copy-operations.test.ts
@@ -32,6 +32,11 @@ vi.mock("../../../wailsjs/go/main/App.js", () => ({
 	SetMinimapVisible: vi.fn(),
 	GetScrollSyncEnabled: vi.fn(),
 	SetScrollSyncEnabled: vi.fn(),
+	DiscardAllChanges: vi.fn(),
+	QuitWithoutSaving: vi.fn(),
+	SaveSelectedFilesAndQuit: vi.fn(),
+	UpdateSaveMenuItems: vi.fn(),
+	UpdateDiffNavigationMenuItems: vi.fn(),
 }));
 
 describe("App Component - Copy Operations", () => {

--- a/frontend/src/tests/integration/edge-cases.test.ts
+++ b/frontend/src/tests/integration/edge-cases.test.ts
@@ -21,6 +21,8 @@ vi.mock("../../../wailsjs/go/main/App.js", () => ({
 	QuitWithoutSaving: vi.fn(),
 	SaveSelectedFilesAndQuit: vi.fn(),
 	SelectFile: vi.fn(),
+	UpdateSaveMenuItems: vi.fn(),
+	UpdateDiffNavigationMenuItems: vi.fn(),
 }));
 
 import {

--- a/frontend/src/tests/integration/edge-cases.test.ts
+++ b/frontend/src/tests/integration/edge-cases.test.ts
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import App from "../../App.svelte";
 
@@ -470,8 +470,8 @@ describe("Edge Cases and Special File Handling", () => {
 		// Create very long file names
 		const longPath =
 			"/very/deep/directory/structure/with/many/nested/folders/that/goes/on/and/on/and/on";
-		const longFileName = "a".repeat(100) + ".txt";
-		const longFullPath = longPath + "/" + longFileName;
+		const longFileName = `${"a".repeat(100)}.txt`;
+		const longFullPath = `${longPath}/${longFileName}`;
 
 		// Mock SelectFile for long paths
 		vi.mocked(SelectFile)

--- a/frontend/src/tests/integration/file-comparison.test.ts
+++ b/frontend/src/tests/integration/file-comparison.test.ts
@@ -21,6 +21,8 @@ vi.mock("../../../wailsjs/go/main/App.js", () => ({
 	QuitWithoutSaving: vi.fn(),
 	SaveSelectedFilesAndQuit: vi.fn(),
 	SelectFile: vi.fn(),
+	UpdateSaveMenuItems: vi.fn(),
+	UpdateDiffNavigationMenuItems: vi.fn(),
 }));
 
 import {

--- a/frontend/src/tests/integration/file-selection.test.ts
+++ b/frontend/src/tests/integration/file-selection.test.ts
@@ -21,6 +21,8 @@ vi.mock("../../../wailsjs/go/main/App.js", () => ({
 	QuitWithoutSaving: vi.fn(),
 	SaveSelectedFilesAndQuit: vi.fn(),
 	SelectFile: vi.fn(),
+	UpdateSaveMenuItems: vi.fn(),
+	UpdateDiffNavigationMenuItems: vi.fn(),
 }));
 
 import {

--- a/frontend/src/tests/integration/keyboard-navigation.test.ts
+++ b/frontend/src/tests/integration/keyboard-navigation.test.ts
@@ -28,6 +28,8 @@ vi.mock("../../../wailsjs/go/main/App", () => ({
 	SetMinimapVisible: vi.fn(),
 	Quit: vi.fn(),
 	HasUnsavedChanges: vi.fn(),
+	UpdateSaveMenuItems: vi.fn(),
+	UpdateDiffNavigationMenuItems: vi.fn(),
 }));
 
 describe("App Component - Keyboard Navigation", () => {

--- a/frontend/src/tests/integration/menu-settings.test.ts
+++ b/frontend/src/tests/integration/menu-settings.test.ts
@@ -21,6 +21,8 @@ vi.mock("../../../wailsjs/go/main/App.js", () => ({
 	QuitWithoutSaving: vi.fn(),
 	SaveSelectedFilesAndQuit: vi.fn(),
 	SelectFile: vi.fn(),
+	UpdateSaveMenuItems: vi.fn(),
+	UpdateDiffNavigationMenuItems: vi.fn(),
 }));
 
 import {

--- a/frontend/src/tests/integration/menu-settings.test.ts
+++ b/frontend/src/tests/integration/menu-settings.test.ts
@@ -25,13 +25,9 @@ vi.mock("../../../wailsjs/go/main/App.js", () => ({
 
 import {
 	CompareFiles,
-	CopyToFile,
 	GetInitialFiles,
 	GetMinimapVisible,
-	HasUnsavedChanges,
-	SaveChanges,
 	SelectFile,
-	SetMinimapVisible,
 } from "../../../wailsjs/go/main/App.js";
 
 import { EventsOn } from "../../../wailsjs/runtime/runtime.js";
@@ -221,7 +217,7 @@ describe("App Component - Menu and Settings", () => {
 		});
 
 		// Start with light mode in localStorage
-		mockLocalStorage["theme"] = "light";
+		mockLocalStorage.theme = "light";
 
 		const { container } = render(App);
 
@@ -263,7 +259,7 @@ describe("App Component - Menu and Settings", () => {
 
 		// Verify localStorage was updated
 		expect(localStorageMock.setItem).toHaveBeenCalledWith("theme", "dark");
-		expect(mockLocalStorage["theme"]).toBe("dark");
+		expect(mockLocalStorage.theme).toBe("dark");
 
 		// Re-open menu to verify button text changed
 		await fireEvent.click(menuButton!);
@@ -294,7 +290,7 @@ describe("App Component - Menu and Settings", () => {
 
 		// Verify localStorage was updated again
 		expect(localStorageMock.setItem).toHaveBeenLastCalledWith("theme", "light");
-		expect(mockLocalStorage["theme"]).toBe("light");
+		expect(mockLocalStorage.theme).toBe("light");
 
 		// Verify the component still works
 		expect(container.querySelector("main")).toBeTruthy();

--- a/frontend/src/tests/integration/minimap-interaction.test.ts
+++ b/frontend/src/tests/integration/minimap-interaction.test.ts
@@ -21,6 +21,8 @@ vi.mock("../../../wailsjs/go/main/App.js", () => ({
 	QuitWithoutSaving: vi.fn(),
 	SaveSelectedFilesAndQuit: vi.fn(),
 	SelectFile: vi.fn(),
+	UpdateSaveMenuItems: vi.fn(),
+	UpdateDiffNavigationMenuItems: vi.fn(),
 }));
 
 import {

--- a/frontend/src/tests/integration/minimap-interaction.test.ts
+++ b/frontend/src/tests/integration/minimap-interaction.test.ts
@@ -406,7 +406,7 @@ describe("Minimap Interaction Tests", () => {
 			await new Promise((resolve) => setTimeout(resolve, 100));
 
 			// Look for tooltip element (might be in document body or near minimap)
-			const tooltip = document.querySelector(
+			const _tooltip = document.querySelector(
 				".minimap-tooltip, .tooltip, [role='tooltip']",
 			);
 			// Just verify tooltip mechanism exists, actual content would require proper initialization

--- a/frontend/src/tests/integration/quit-dialog.test.ts
+++ b/frontend/src/tests/integration/quit-dialog.test.ts
@@ -21,6 +21,8 @@ vi.mock("../../../wailsjs/go/main/App.js", () => ({
 	QuitWithoutSaving: vi.fn(),
 	SaveSelectedFilesAndQuit: vi.fn(),
 	SelectFile: vi.fn(),
+	UpdateSaveMenuItems: vi.fn(),
+	UpdateDiffNavigationMenuItems: vi.fn(),
 }));
 
 import {

--- a/frontend/src/tests/integration/save-operations.test.ts
+++ b/frontend/src/tests/integration/save-operations.test.ts
@@ -21,6 +21,8 @@ vi.mock("../../../wailsjs/go/main/App.js", () => ({
 	QuitWithoutSaving: vi.fn(),
 	SaveSelectedFilesAndQuit: vi.fn(),
 	SelectFile: vi.fn(),
+	UpdateSaveMenuItems: vi.fn(),
+	UpdateDiffNavigationMenuItems: vi.fn(),
 }));
 
 import {

--- a/frontend/src/tests/integration/save-operations.test.ts
+++ b/frontend/src/tests/integration/save-operations.test.ts
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import App from "../../App.svelte";
 
@@ -31,10 +31,7 @@ import {
 	HasUnsavedChanges,
 	SaveChanges,
 	SelectFile,
-	SetMinimapVisible,
 } from "../../../wailsjs/go/main/App.js";
-
-import { EventsOn } from "../../../wailsjs/runtime/runtime.js";
 
 describe("Save and Unsaved Changes Tests", () => {
 	beforeEach(() => {
@@ -150,7 +147,7 @@ describe("Save and Unsaved Changes Tests", () => {
 		// but due to test environment limitations with event handlers, we can't test this fully
 
 		// Test keyboard shortcut structure
-		const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+		const _isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
 		// Note: keyboard shortcuts also have limitations in test environment
 		// In a real app, Cmd/Ctrl+S would save files with unsaved changes
 	});

--- a/frontend/src/tests/integration/scroll-sync.test.ts
+++ b/frontend/src/tests/integration/scroll-sync.test.ts
@@ -21,6 +21,8 @@ vi.mock("../../../wailsjs/go/main/App.js", () => ({
 	QuitWithoutSaving: vi.fn(),
 	SaveSelectedFilesAndQuit: vi.fn(),
 	SelectFile: vi.fn(),
+	UpdateSaveMenuItems: vi.fn(),
+	UpdateDiffNavigationMenuItems: vi.fn(),
 }));
 
 import {

--- a/frontend/src/tests/integration/startup.test.ts
+++ b/frontend/src/tests/integration/startup.test.ts
@@ -21,6 +21,8 @@ vi.mock("../../../wailsjs/go/main/App.js", () => ({
 	QuitWithoutSaving: vi.fn(),
 	SaveSelectedFilesAndQuit: vi.fn(),
 	SelectFile: vi.fn(),
+	UpdateSaveMenuItems: vi.fn(),
+	UpdateDiffNavigationMenuItems: vi.fn(),
 }));
 
 import {

--- a/frontend/src/tests/integration/startup.test.ts
+++ b/frontend/src/tests/integration/startup.test.ts
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import App from "../../App.svelte";
 
@@ -26,7 +26,6 @@ vi.mock("../../../wailsjs/go/main/App.js", () => ({
 import {
 	CompareFiles,
 	GetInitialFiles,
-	GetMinimapVisible,
 	SelectFile,
 } from "../../../wailsjs/go/main/App.js";
 

--- a/frontend/src/utils/keyboard.ts
+++ b/frontend/src/utils/keyboard.ts
@@ -2,7 +2,7 @@
  * Keyboard event handling utilities
  *
  * Available keyboard shortcuts:
- * - Cmd/Ctrl + S: Save both files
+ * - Cmd/Ctrl + S: Save all files with changes
  * - ArrowDown or j: Jump to next diff
  * - ArrowUp or k: Jump to previous diff
  * - Shift + L: Copy current diff from right to left

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -41,10 +41,20 @@ export function SaveSelectedFilesAndQuit(arg1:Array<string>):Promise<void>;
 
 export function SelectFile():Promise<string>;
 
+export function SetDiscardMenuItem(arg1:menu.MenuItem):Promise<void>;
+
 export function SetMinimapMenuItem(arg1:menu.MenuItem):Promise<void>;
 
 export function SetMinimapVisible(arg1:boolean):Promise<void>;
 
+export function SetSaveAllMenuItem(arg1:menu.MenuItem):Promise<void>;
+
+export function SetSaveLeftMenuItem(arg1:menu.MenuItem):Promise<void>;
+
+export function SetSaveRightMenuItem(arg1:menu.MenuItem):Promise<void>;
+
 export function SetUndoMenuItem(arg1:menu.MenuItem):Promise<void>;
 
 export function UndoLastOperation():Promise<void>;
+
+export function UpdateSaveMenuItems(arg1:boolean,arg2:boolean):Promise<void>;

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -47,6 +47,10 @@ export function SetMinimapMenuItem(arg1:menu.MenuItem):Promise<void>;
 
 export function SetMinimapVisible(arg1:boolean):Promise<void>;
 
+export function SetNextDiffMenuItem(arg1:menu.MenuItem):Promise<void>;
+
+export function SetPrevDiffMenuItem(arg1:menu.MenuItem):Promise<void>;
+
 export function SetSaveAllMenuItem(arg1:menu.MenuItem):Promise<void>;
 
 export function SetSaveLeftMenuItem(arg1:menu.MenuItem):Promise<void>;
@@ -56,5 +60,7 @@ export function SetSaveRightMenuItem(arg1:menu.MenuItem):Promise<void>;
 export function SetUndoMenuItem(arg1:menu.MenuItem):Promise<void>;
 
 export function UndoLastOperation():Promise<void>;
+
+export function UpdateDiffNavigationMenuItems(arg1:boolean,arg2:boolean):Promise<void>;
 
 export function UpdateSaveMenuItems(arg1:boolean,arg2:boolean):Promise<void>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -78,6 +78,10 @@ export function SelectFile() {
   return window['go']['main']['App']['SelectFile']();
 }
 
+export function SetDiscardMenuItem(arg1) {
+  return window['go']['main']['App']['SetDiscardMenuItem'](arg1);
+}
+
 export function SetMinimapMenuItem(arg1) {
   return window['go']['main']['App']['SetMinimapMenuItem'](arg1);
 }
@@ -86,10 +90,26 @@ export function SetMinimapVisible(arg1) {
   return window['go']['main']['App']['SetMinimapVisible'](arg1);
 }
 
+export function SetSaveAllMenuItem(arg1) {
+  return window['go']['main']['App']['SetSaveAllMenuItem'](arg1);
+}
+
+export function SetSaveLeftMenuItem(arg1) {
+  return window['go']['main']['App']['SetSaveLeftMenuItem'](arg1);
+}
+
+export function SetSaveRightMenuItem(arg1) {
+  return window['go']['main']['App']['SetSaveRightMenuItem'](arg1);
+}
+
 export function SetUndoMenuItem(arg1) {
   return window['go']['main']['App']['SetUndoMenuItem'](arg1);
 }
 
 export function UndoLastOperation() {
   return window['go']['main']['App']['UndoLastOperation']();
+}
+
+export function UpdateSaveMenuItems(arg1, arg2) {
+  return window['go']['main']['App']['UpdateSaveMenuItems'](arg1, arg2);
 }

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -90,6 +90,14 @@ export function SetMinimapVisible(arg1) {
   return window['go']['main']['App']['SetMinimapVisible'](arg1);
 }
 
+export function SetNextDiffMenuItem(arg1) {
+  return window['go']['main']['App']['SetNextDiffMenuItem'](arg1);
+}
+
+export function SetPrevDiffMenuItem(arg1) {
+  return window['go']['main']['App']['SetPrevDiffMenuItem'](arg1);
+}
+
 export function SetSaveAllMenuItem(arg1) {
   return window['go']['main']['App']['SetSaveAllMenuItem'](arg1);
 }
@@ -108,6 +116,10 @@ export function SetUndoMenuItem(arg1) {
 
 export function UndoLastOperation() {
   return window['go']['main']['App']['UndoLastOperation']();
+}
+
+export function UpdateDiffNavigationMenuItems(arg1, arg2) {
+  return window['go']['main']['App']['UpdateDiffNavigationMenuItems'](arg1, arg2);
 }
 
 export function UpdateSaveMenuItems(arg1, arg2) {

--- a/main.go
+++ b/main.go
@@ -102,6 +102,23 @@ func BuildMenu(app *App) *menu.Menu {
 		minimapItem.Checked = true
 	}
 
+	// Go menu
+	goMenu := appMenu.AddSubmenu("Go")
+
+	// Previous Diff
+	prevDiffItem := goMenu.AddText("Previous Diff", keys.Key("k"), func(_ *menu.CallbackData) {
+		runtime.EventsEmit(app.ctx, "menu-prev-diff")
+	})
+	app.SetPrevDiffMenuItem(prevDiffItem)
+	prevDiffItem.Disabled = true
+
+	// Next Diff
+	nextDiffItem := goMenu.AddText("Next Diff", keys.Key("j"), func(_ *menu.CallbackData) {
+		runtime.EventsEmit(app.ctx, "menu-next-diff")
+	})
+	app.SetNextDiffMenuItem(nextDiffItem)
+	nextDiffItem.Disabled = true
+
 	return appMenu
 }
 

--- a/main.go
+++ b/main.go
@@ -30,6 +30,32 @@ func BuildMenu(app *App) *menu.Menu {
 
 	// File menu
 	fileMenu := appMenu.AddSubmenu("File")
+
+	// Save submenu
+	saveMenu := fileMenu.AddSubmenu("Save")
+
+	// Save Left Pane
+	saveLeftItem := saveMenu.AddText("Save Left Pane", nil, func(_ *menu.CallbackData) {
+		runtime.EventsEmit(app.ctx, "menu-save-left")
+	})
+	app.SetSaveLeftMenuItem(saveLeftItem)
+	saveLeftItem.Disabled = true
+
+	// Save Right Pane
+	saveRightItem := saveMenu.AddText("Save Right Pane", nil, func(_ *menu.CallbackData) {
+		runtime.EventsEmit(app.ctx, "menu-save-right")
+	})
+	app.SetSaveRightMenuItem(saveRightItem)
+	saveRightItem.Disabled = true
+
+	// Save All
+	saveAllItem := saveMenu.AddText("Save All", keys.CmdOrCtrl("s"), func(_ *menu.CallbackData) {
+		runtime.EventsEmit(app.ctx, "menu-save-all")
+	})
+	app.SetSaveAllMenuItem(saveAllItem)
+	saveAllItem.Disabled = true
+
+	fileMenu.AddSeparator()
 	fileMenu.AddText("Quit", keys.CmdOrCtrl("q"), func(_ *menu.CallbackData) {
 		runtime.Quit(app.ctx)
 	})
@@ -52,6 +78,13 @@ func BuildMenu(app *App) *menu.Menu {
 
 	// Set initial state
 	undoItem.Disabled = true
+
+	// Discard All Changes menu item
+	discardItem := editMenu.AddText("Discard All Changes", nil, func(_ *menu.CallbackData) {
+		runtime.EventsEmit(app.ctx, "menu-discard-all")
+	})
+	app.SetDiscardMenuItem(discardItem)
+	discardItem.Disabled = true
 
 	// View menu
 	viewMenu := appMenu.AddSubmenu("View")


### PR DESCRIPTION
## Summary
- Added Edit > Discard All Changes menu item for clearing all unsaved changes
- Added File > Save submenu with Save Left Pane, Save Right Pane, and Save All options
- Added Go menu with Previous Diff (k) and Next Diff (j) navigation items
- Implemented dynamic menu state management based on application state

## Implementation Details

### Menu Structure
- **Edit > Discard All Changes**: Clears all cached changes and refreshes the comparison
- **File > Save**:
  - Save Left Pane: Saves only the left file
  - Save Right Pane: Saves only the right file  
  - Save All (Cmd/Ctrl+S): Saves both files if they have unsaved changes
- **Go**:
  - Previous Diff (k): Navigate to previous difference
  - Next Diff (j): Navigate to next difference

### State Management
- Menu items are dynamically enabled/disabled based on:
  - Unsaved changes status for save/discard items
  - Current diff position for navigation items
- Backend (Go) and frontend (Svelte) stay synchronized through Wails event system

### Keyboard Shortcuts
- Cmd/Ctrl+S: Save All (saves both files if needed)
- k: Previous Diff
- j: Next Diff
- All shortcuts respect the same state management as menu items

## Test Plan
- [x] Verify all menu items appear in correct positions
- [x] Test save menu items enable/disable based on unsaved changes
- [x] Test discard menu item clears all changes
- [x] Test Go menu navigation with keyboard shortcuts
- [x] Test menu state updates when navigating diffs
- [x] Update manual test script with new menu functionality