### PR TITLE
fix: navigation bugs in diff viewer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,8 @@ Test files - primarily used for manual testing - are located in `resources/sampl
 * **Commit messages**: 
   * Keep subject line ≤ 50 characters for readability
   * Do NOT include "Generated with" or "Co-Authored-By" lines
+* **Pull requests**:
+  * Do NOT include "Generated with" or emoji robot lines in PR descriptions
 * Use pull requests for all merges to `main`
 * Run `wails build` and ensure no errors before merging
 

--- a/frontend/src/components/DiffGutter.svelte
+++ b/frontend/src/components/DiffGutter.svelte
@@ -58,35 +58,36 @@ export function setScrollLeft(scrollLeft: number): void {
 	<div class="gutter-content" style="height: calc({lines.length} * var(--line-height));">
 		{#each lines as line, index}
 			{@const chunk = getChunkForLine(index)}
-			{@const isFirstInChunk = chunk ? isFirstLineOfChunk(index, chunk) : false}
+			{@const diffChunk = diffChunks.find(c => index >= c.startIndex && index <= c.endIndex)}
+			{@const isFirstInDiffChunk = diffChunk && index === diffChunk.startIndex}
 			{@const isLastInChunk = chunk ? index === chunk.endIndex : false}
 			
-			<div class="gutter-line {chunk && isFirstInChunk ? 'chunk-start' : ''} {chunk && isLastInChunk ? 'chunk-end' : ''} {isLineHighlighted(index) ? 'current-diff-line' : ''}">
-			{#if chunk && isFirstInChunk}
-				<!-- Show chunk arrows only on the first line of the chunk -->
-				<div class="chunk-actions" style="--chunk-height: {chunk.lines};">
-					{#if isLineHighlighted(index)}
+			<div class="gutter-line {chunk && isFirstLineOfChunk(index, chunk) ? 'chunk-start' : ''} {chunk && isLastInChunk ? 'chunk-end' : ''} {isLineHighlighted(index) ? 'current-diff-line' : ''}">
+			{#if diffChunk && isFirstInDiffChunk && line.type !== 'same'}
+				<!-- Show chunk arrows only on the first line of the diff chunk -->
+				<div class="chunk-actions" style="--chunk-height: {diffChunk.endIndex - diffChunk.startIndex + 1};">
+					{#if currentDiffChunkIndex !== -1 && diffChunks[currentDiffChunkIndex] && diffChunk.startIndex === diffChunks[currentDiffChunkIndex].startIndex}
 						<div class="current-diff-indicator" title="Current diff"></div>
 					{/if}
-					{#if chunk.type === 'added'}
-						<button class="gutter-arrow left-side-arrow chunk-arrow" on:click={() => dispatch('deleteChunkFromRight', chunk)} title="Delete chunk from right ({chunk.lines} lines)">
+					{#if line.type === 'added'}
+						<button class="gutter-arrow left-side-arrow chunk-arrow" on:click={() => dispatch('deleteChunkFromRight', chunk)} title="Delete chunk from right ({diffChunk.endIndex - diffChunk.startIndex + 1} lines)">
 							→
 						</button>
-						<button class="gutter-arrow right-side-arrow chunk-arrow" on:click={() => dispatch('copyChunkToLeft', chunk)} title="Copy chunk to left ({chunk.lines} lines)">
+						<button class="gutter-arrow right-side-arrow chunk-arrow" on:click={() => dispatch('copyChunkToLeft', chunk)} title="Copy chunk to left ({diffChunk.endIndex - diffChunk.startIndex + 1} lines)">
 							←
 						</button>
-					{:else if chunk.type === 'removed'}
-						<button class="gutter-arrow left-side-arrow chunk-arrow" on:click={() => dispatch('copyChunkToRight', chunk)} title="Copy chunk to right ({chunk.lines} lines)">
+					{:else if line.type === 'removed'}
+						<button class="gutter-arrow left-side-arrow chunk-arrow" on:click={() => dispatch('copyChunkToRight', chunk)} title="Copy chunk to right ({diffChunk.endIndex - diffChunk.startIndex + 1} lines)">
 							→
 						</button>
-						<button class="gutter-arrow right-side-arrow chunk-arrow" on:click={() => dispatch('deleteChunkFromLeft', chunk)} title="Delete chunk from left ({chunk.lines} lines)">
+						<button class="gutter-arrow right-side-arrow chunk-arrow" on:click={() => dispatch('deleteChunkFromLeft', chunk)} title="Delete chunk from left ({diffChunk.endIndex - diffChunk.startIndex + 1} lines)">
 							←
 						</button>
-					{:else if chunk.type === 'modified'}
-						<button class="gutter-arrow left-side-arrow chunk-arrow modified-arrow" on:click={() => dispatch('copyModifiedChunkToRight', chunk)} title="Copy left version to right ({chunk.lines} lines)">
+					{:else if line.type === 'modified'}
+						<button class="gutter-arrow left-side-arrow chunk-arrow modified-arrow" on:click={() => dispatch('copyModifiedChunkToRight', chunk)} title="Copy left version to right ({diffChunk.endIndex - diffChunk.startIndex + 1} lines)">
 							→
 						</button>
-						<button class="gutter-arrow right-side-arrow chunk-arrow modified-arrow" on:click={() => dispatch('copyModifiedChunkToLeft', chunk)} title="Copy right version to left ({chunk.lines} lines)">
+						<button class="gutter-arrow right-side-arrow chunk-arrow modified-arrow" on:click={() => dispatch('copyModifiedChunkToLeft', chunk)} title="Copy right version to left ({diffChunk.endIndex - diffChunk.startIndex + 1} lines)">
 							←
 						</button>
 					{/if}

--- a/frontend/src/components/DiffViewer.test.ts
+++ b/frontend/src/components/DiffViewer.test.ts
@@ -16,8 +16,13 @@ vi.mock("../utils/diff", () => ({
 
 vi.mock("../utils/scrollSync", () => ({
 	calculateScrollToCenterLine: vi.fn(
-		(lineIndex, lineHeight, viewportHeight) => {
-			return lineIndex * lineHeight - viewportHeight / 2;
+		(lineIndex, lineHeight, viewportHeight, scrollHeight) => {
+			const idealScroll = lineIndex * lineHeight - viewportHeight / 2;
+			if (scrollHeight !== undefined) {
+				const maxScroll = Math.max(0, scrollHeight - viewportHeight);
+				return Math.min(Math.max(0, idealScroll), maxScroll);
+			}
+			return Math.max(0, idealScroll);
 		},
 	),
 }));
@@ -72,6 +77,10 @@ describe("DiffViewer", () => {
 		areFilesIdentical: false,
 		isSameFile: false,
 		lineNumberWidth: "50px",
+		diffChunks: [
+			{ startIndex: 1, endIndex: 1 }, // removed line
+			{ startIndex: 2, endIndex: 2 }, // added line
+		],
 	};
 
 	beforeEach(() => {

--- a/frontend/src/components/Minimap.test.ts
+++ b/frontend/src/components/Minimap.test.ts
@@ -45,6 +45,15 @@ describe("Minimap", () => {
 		{ startIndex: 11, endIndex: 13 },
 	];
 
+	// Mock diff lines to match the chunks
+	const mockDiffLines = Array(14).fill(null).map((_, i) => {
+		if (i >= 0 && i <= 4) return { type: "same", leftNumber: i + 1, rightNumber: i + 1 };
+		if (i >= 5 && i <= 7) return { type: "added", leftNumber: null, rightNumber: i + 1 };
+		if (i >= 8 && i <= 10) return { type: "removed", leftNumber: i - 7 + 6, rightNumber: null };
+		if (i >= 11 && i <= 13) return { type: "modified", leftNumber: i - 11 + 9, rightNumber: i - 11 + 9 };
+		return { type: "same", leftNumber: i + 1, rightNumber: i + 1 };
+	});
+
 	it("should not render when show is false", () => {
 		const { container } = render(Minimap, {
 			show: false,
@@ -81,6 +90,8 @@ describe("Minimap", () => {
 			show: true,
 			lineChunks: mockLineChunks,
 			totalLines: 20,
+			diffChunks: mockDiffChunks,
+			diffLines: mockDiffLines,
 		});
 
 		const chunks = container.querySelectorAll(".minimap-chunk");
@@ -99,6 +110,7 @@ describe("Minimap", () => {
 			totalLines: 20,
 			currentDiffChunkIndex: 1,
 			diffChunks: mockDiffChunks,
+			diffLines: mockDiffLines,
 		});
 
 		const currentChunk = container.querySelector(".minimap-current");
@@ -175,6 +187,8 @@ describe("Minimap", () => {
 			show: true,
 			lineChunks: mockLineChunks,
 			totalLines: 20,
+			diffChunks: mockDiffChunks,
+			diffLines: mockDiffLines,
 		});
 
 		const addedChunk = container.querySelector(".minimap-added");
@@ -186,10 +200,13 @@ describe("Minimap", () => {
 			show: true,
 			lineChunks: mockLineChunks,
 			totalLines: 20,
+			diffChunks: mockDiffChunks,
+			diffLines: mockDiffLines,
 		});
 
 		const addedChunk = container.querySelector(".minimap-added");
 		expect(addedChunk).toHaveAttribute("data-chunk-start", "5");
 		expect(addedChunk).toHaveAttribute("data-chunk-lines", "3");
+		expect(addedChunk).toHaveAttribute("data-chunk-index", "0");
 	});
 });

--- a/frontend/src/utils/diffChunks.test.ts
+++ b/frontend/src/utils/diffChunks.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import type { HighlightedDiffLine } from "../types/diff";
+import { calculateDiffChunks } from "./diffChunks";
+
+describe("calculateDiffChunks", () => {
+	it("should return empty array for empty input", () => {
+		expect(calculateDiffChunks([])).toEqual([]);
+	});
+
+	it("should return empty array for null input", () => {
+		expect(calculateDiffChunks(null as any)).toEqual([]);
+	});
+
+	it("should return empty array for file with only same lines", () => {
+		const lines: HighlightedDiffLine[] = [
+			{ type: "same", leftLine: "line1", rightLine: "line1" },
+			{ type: "same", leftLine: "line2", rightLine: "line2" },
+			{ type: "same", leftLine: "line3", rightLine: "line3" },
+		] as HighlightedDiffLine[];
+
+		expect(calculateDiffChunks(lines)).toEqual([]);
+	});
+
+	it("should identify single diff chunk", () => {
+		const lines: HighlightedDiffLine[] = [
+			{ type: "same", leftLine: "line1", rightLine: "line1" },
+			{ type: "added", leftLine: "", rightLine: "added" },
+			{ type: "same", leftLine: "line3", rightLine: "line3" },
+		] as HighlightedDiffLine[];
+
+		expect(calculateDiffChunks(lines)).toEqual([
+			{ startIndex: 1, endIndex: 1 },
+		]);
+	});
+
+	it("should group consecutive diff lines into single chunk", () => {
+		const lines: HighlightedDiffLine[] = [
+			{ type: "same", leftLine: "line1", rightLine: "line1" },
+			{ type: "removed", leftLine: "removed1", rightLine: "" },
+			{ type: "removed", leftLine: "removed2", rightLine: "" },
+			{ type: "added", leftLine: "", rightLine: "added1" },
+			{ type: "added", leftLine: "", rightLine: "added2" },
+			{ type: "same", leftLine: "line6", rightLine: "line6" },
+		] as HighlightedDiffLine[];
+
+		expect(calculateDiffChunks(lines)).toEqual([
+			{ startIndex: 1, endIndex: 4 },
+		]);
+	});
+
+	it("should identify multiple separate diff chunks", () => {
+		const lines: HighlightedDiffLine[] = [
+			{ type: "same", leftLine: "line1", rightLine: "line1" },
+			{ type: "modified", leftLine: "old", rightLine: "new" },
+			{ type: "same", leftLine: "line3", rightLine: "line3" },
+			{ type: "same", leftLine: "line4", rightLine: "line4" },
+			{ type: "added", leftLine: "", rightLine: "added" },
+			{ type: "same", leftLine: "line6", rightLine: "line6" },
+		] as HighlightedDiffLine[];
+
+		expect(calculateDiffChunks(lines)).toEqual([
+			{ startIndex: 1, endIndex: 1 },
+			{ startIndex: 4, endIndex: 4 },
+		]);
+	});
+
+	it("should handle diff at start of file", () => {
+		const lines: HighlightedDiffLine[] = [
+			{ type: "added", leftLine: "", rightLine: "added1" },
+			{ type: "added", leftLine: "", rightLine: "added2" },
+			{ type: "same", leftLine: "line3", rightLine: "line3" },
+		] as HighlightedDiffLine[];
+
+		expect(calculateDiffChunks(lines)).toEqual([
+			{ startIndex: 0, endIndex: 1 },
+		]);
+	});
+
+	it("should handle diff at end of file", () => {
+		const lines: HighlightedDiffLine[] = [
+			{ type: "same", leftLine: "line1", rightLine: "line1" },
+			{ type: "removed", leftLine: "removed", rightLine: "" },
+			{ type: "added", leftLine: "", rightLine: "added" },
+		] as HighlightedDiffLine[];
+
+		expect(calculateDiffChunks(lines)).toEqual([
+			{ startIndex: 1, endIndex: 2 },
+		]);
+	});
+
+	it("should handle file with all diff lines", () => {
+		const lines: HighlightedDiffLine[] = [
+			{ type: "removed", leftLine: "removed1", rightLine: "" },
+			{ type: "added", leftLine: "", rightLine: "added1" },
+			{ type: "modified", leftLine: "old", rightLine: "new" },
+		] as HighlightedDiffLine[];
+
+		expect(calculateDiffChunks(lines)).toEqual([
+			{ startIndex: 0, endIndex: 2 },
+		]);
+	});
+});

--- a/frontend/src/utils/diffChunks.ts
+++ b/frontend/src/utils/diffChunks.ts
@@ -1,0 +1,49 @@
+import type { HighlightedDiffLine } from "../types/diff";
+
+export interface DiffChunk {
+	startIndex: number;
+	endIndex: number;
+}
+
+/**
+ * Calculates diff chunks from highlighted diff lines.
+ * Groups consecutive lines that are not "same" into chunks.
+ *
+ * @param lines - Array of highlighted diff lines
+ * @returns Array of diff chunks with start and end indices
+ */
+export function calculateDiffChunks(lines: HighlightedDiffLine[]): DiffChunk[] {
+	if (!lines || lines.length === 0) {
+		return [];
+	}
+
+	const chunks: DiffChunk[] = [];
+	let inDiff = false;
+	let startIndex = -1;
+
+	lines.forEach((line, index) => {
+		if (line.type !== "same") {
+			if (!inDiff) {
+				// Start of a new diff chunk
+				inDiff = true;
+				startIndex = index;
+			}
+		} else {
+			if (inDiff) {
+				// End of diff chunk
+				chunks.push({ startIndex, endIndex: index - 1 });
+				inDiff = false;
+			}
+		}
+	});
+
+	// Handle case where file ends with a diff
+	if (inDiff && startIndex !== -1) {
+		chunks.push({
+			startIndex,
+			endIndex: lines.length - 1,
+		});
+	}
+
+	return chunks;
+}

--- a/frontend/src/utils/scrollSync.test.ts
+++ b/frontend/src/utils/scrollSync.test.ts
@@ -239,6 +239,98 @@ describe("scrollSync", () => {
 			// Line 5: middle at position 110 (5*20 + 10), centered would be -90, but clamped to 0
 			expect(calculateScrollToCenterLine(5, 20, 400)).toBe(0);
 		});
+
+		it("should handle edge case for 13th diff with specific viewport", () => {
+			const lineHeight = 19.2; // from CSS var(--line-height)
+			const viewportHeight = 600; // typical viewport height
+
+			// Test for the 13th diff (index 12 if 0-based)
+			// Let's say it's at line 250
+			const lineIndex = 250;
+
+			// Calculate expected scroll position
+			const linePosition = lineIndex * lineHeight + lineHeight / 2;
+			const middleOfViewport = viewportHeight / 2;
+			const expectedScroll = Math.max(0, linePosition - middleOfViewport);
+
+			const result = calculateScrollToCenterLine(
+				lineIndex,
+				lineHeight,
+				viewportHeight,
+			);
+			expect(result).toBe(expectedScroll);
+			expect(result).toBe(4509.6); // (250 * 19.2 + 9.6) - 300 = 4809.6 - 300 = 4509.6
+		});
+
+		it("should handle very large line numbers", () => {
+			const lineHeight = 19.2;
+			const viewportHeight = 600;
+
+			// Test with a very large line number
+			const lineIndex = 1000;
+			const result = calculateScrollToCenterLine(
+				lineIndex,
+				lineHeight,
+				viewportHeight,
+			);
+
+			// Should still center correctly
+			const expectedScroll =
+				lineIndex * lineHeight + lineHeight / 2 - viewportHeight / 2;
+			expect(result).toBe(expectedScroll);
+			expect(result).toBe(18909.6); // (1000 * 19.2 + 9.6) - 300 = 19209.6 - 300 = 18909.6
+		});
+
+		it("should properly center when scrolling is constrained by max scroll", () => {
+			const lineHeight = 19.2;
+			const viewportHeight = 600;
+			const scrollHeight = 5760; // 300 lines * 19.2
+
+			// Simulate a case where we can't center because we're near the bottom
+			// Max scroll = scrollHeight - viewportHeight = 5760 - 600 = 5160
+			// If we try to center line 290, ideal scroll = (290 * 19.2 + 9.6) - 300 = 5577.6 - 300 = 5277.6
+			// But max scroll is 5160, so it should be clamped
+
+			const lineIndex = 290;
+			const result = calculateScrollToCenterLine(
+				lineIndex,
+				lineHeight,
+				viewportHeight,
+				scrollHeight,
+			);
+
+			// The function should clamp to max scroll
+			expect(result).toBe(5160); // Max scroll position
+		});
+
+		it("should handle 13th diff near bottom properly", () => {
+			const lineHeight = 19.2;
+			const viewportHeight = 600;
+			// Simulate a file with the 13th diff near the bottom
+			const totalLines = 300;
+			const scrollHeight = totalLines * lineHeight; // 5760
+
+			// 13th diff at line 280 (near bottom)
+			const lineIndex = 280;
+
+			// Calculate what should happen
+			const idealScroll =
+				lineIndex * lineHeight + lineHeight / 2 - viewportHeight / 2;
+			const maxScroll = scrollHeight - viewportHeight;
+			const expectedScroll = Math.min(idealScroll, maxScroll);
+
+			const result = calculateScrollToCenterLine(
+				lineIndex,
+				lineHeight,
+				viewportHeight,
+				scrollHeight,
+			);
+			expect(result).toBe(expectedScroll);
+			// idealScroll = (280 * 19.2 + 9.6) - 300 = 5385.6 - 300 = 5085.6
+			// maxScroll = 5760 - 600 = 5160
+			// Since 5085.6 < 5160, it's not clamped
+			expect(result).toBe(5085.6);
+		});
 	});
 
 	describe("clampScrollPosition", () => {

--- a/frontend/src/utils/scrollSync.ts
+++ b/frontend/src/utils/scrollSync.ts
@@ -189,13 +189,24 @@ export function calculateScrollToCenterLine(
 	lineIndex: number,
 	lineHeight: number,
 	viewportHeight: number,
+	scrollHeight?: number,
 ): number {
 	// Calculate the position of the middle of the target line
 	const linePosition = lineIndex * lineHeight + lineHeight / 2;
 	const middleOfViewport = viewportHeight / 2;
-	// Calculate scroll position to center the line
-	const scrollPosition = linePosition - middleOfViewport;
-	return Math.max(0, scrollPosition);
+	// Calculate ideal scroll position to center the line
+	const idealScrollPosition = linePosition - middleOfViewport;
+
+	// Clamp to valid scroll range
+	let scrollPosition = Math.max(0, idealScrollPosition);
+
+	// If scrollHeight is provided, also clamp to maximum scroll
+	if (scrollHeight !== undefined) {
+		const maxScroll = Math.max(0, scrollHeight - viewportHeight);
+		scrollPosition = Math.min(scrollPosition, maxScroll);
+	}
+
+	return scrollPosition;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixed scroll timing issue where diffs weren't centering properly due to Svelte prop reactivity
- Fixed duplicate activity indicators appearing for multi-line diff chunks
- Fixed minimap not showing highlights when navigating via keyboard

## Changes
1. **Scroll timing fix**: Pass chunk index directly to `scrollToLine()` instead of relying on prop updates
2. **Activity indicators**: Show arrows only on first line of diff chunks using `diffChunks` array
3. **Minimap highlighting**: Refactored to iterate over `diffChunks` directly and determine chunk type from line data

## Test plan
- [x] Navigate through diffs using arrow keys - all diffs should center properly
- [x] Check multi-line diffs - should show only one set of arrows per chunk
- [x] Navigate with keyboard - minimap should highlight current diff
- [x] Click minimap chunks - navigation and highlighting should work
- [x] All existing tests pass