### PR TITLE
fix: add Intel Mac support via universal binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 .PHONY: build dev clean install-cli
 
 # Build the application and install CLI script
+# Builds a universal binary for macOS (supports both Intel and Apple Silicon)
 build:
 	@echo "Building Weld..."
-	@wails build
+	@wails build -platform darwin/universal
 	@echo "Installing CLI script into app bundle..."
 	@cp bin/weld build/bin/Weld.app/Contents/Resources/weld
 	@chmod +x build/bin/Weld.app/Contents/Resources/weld


### PR DESCRIPTION
## Summary
Fixes macOS builds to create universal binaries that support both Intel and Apple Silicon Macs.

## Problem
The current build process was creating ARM64-only binaries, which don't work on Intel Macs. Users with Intel Macs were getting an error when trying to run Weld.

## Solution
Added `-platform darwin/universal` flag to the `wails build` command in the Makefile. This creates a universal binary that contains both x86_64 (Intel) and arm64 (Apple Silicon) architectures.

## Testing
- [ ] Build locally with `make build`
- [ ] Test on Intel Mac
- [ ] Test on Apple Silicon Mac
- [ ] Verify file size increase is reasonable (universal binaries are larger)

Fixes #28