### PR TITLE
fix: CLI arguments not passing to frontend

### DIFF
--- a/app.go
+++ b/app.go
@@ -92,9 +92,18 @@ func (a *App) startup(ctx context.Context) {
 	a.ctx = ctx
 }
 
+// InitialFiles represents the initial file paths for comparison
+type InitialFiles struct {
+	LeftFile  string `json:"leftFile"`
+	RightFile string `json:"rightFile"`
+}
+
 // GetInitialFiles returns the initial file paths passed via command line
-func (a *App) GetInitialFiles() (string, string) {
-	return a.InitialLeftFile, a.InitialRightFile
+func (a *App) GetInitialFiles() InitialFiles {
+	return InitialFiles{
+		LeftFile:  a.InitialLeftFile,
+		RightFile: a.InitialRightFile,
+	}
 }
 
 // SelectFile opens a file dialog and returns the selected file path
@@ -213,7 +222,6 @@ func (a *App) ReadFileContent(filepath string) ([]string, error) {
 
 // CompareFiles compares two files and returns diff results
 func (a *App) CompareFiles(leftPath, rightPath string) (*DiffResult, error) {
-
 	leftLines, err := a.ReadFileContentWithCache(leftPath)
 	if err != nil {
 		return nil, fmt.Errorf("error reading left file: %w", err)

--- a/app_test.go
+++ b/app_test.go
@@ -951,14 +951,14 @@ func TestApp_GetInitialFiles(t *testing.T) {
 		InitialRightFile: "/path/to/right.txt",
 	}
 
-	left, right := app.GetInitialFiles()
+	files := app.GetInitialFiles()
 
-	if left != "/path/to/left.txt" {
-		t.Errorf("Expected left file %s, got %s", "/path/to/left.txt", left)
+	if files.LeftFile != "/path/to/left.txt" {
+		t.Errorf("Expected left file %s, got %s", "/path/to/left.txt", files.LeftFile)
 	}
 
-	if right != "/path/to/right.txt" {
-		t.Errorf("Expected right file %s, got %s", "/path/to/right.txt", right)
+	if files.RightFile != "/path/to/right.txt" {
+		t.Errorf("Expected right file %s, got %s", "/path/to/right.txt", files.RightFile)
 	}
 }
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1509,9 +1509,9 @@ onMount(async () => {
 
 	// Check for initial files from command line
 	try {
-		const [initialLeft, initialRight] = await GetInitialFiles();
-		if (initialLeft && initialRight) {
-			fileStore.setBothFiles(initialLeft, initialRight);
+		const initialFiles = await GetInitialFiles();
+		if (initialFiles && initialFiles.leftFile && initialFiles.rightFile) {
+			fileStore.setBothFiles(initialFiles.leftFile, initialFiles.rightFile);
 
 			// Automatically compare the files
 			await compareBothFiles();

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -15,7 +15,7 @@ export function CopyToFile(arg1:string,arg2:string,arg3:number,arg4:string):Prom
 
 export function DiscardAllChanges():Promise<void>;
 
-export function GetInitialFiles():Promise<string|string>;
+export function GetInitialFiles():Promise<main.InitialFiles>;
 
 export function GetLastOperationDescription():Promise<string>;
 

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -69,6 +69,20 @@ export namespace main {
 		    return a;
 		}
 	}
+	export class InitialFiles {
+	    leftFile: string;
+	    rightFile: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new InitialFiles(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.leftFile = source["leftFile"];
+	        this.rightFile = source["rightFile"];
+	    }
+	}
 
 }
 

--- a/main.go
+++ b/main.go
@@ -147,7 +147,7 @@ func main() {
 
 	// Check if we have file arguments
 	if len(args) >= 2 {
-		// Convert to absolute paths
+		// Convert to absolute paths (shell already handles tilde expansion)
 		var err error
 		leftFile, err = filepath.Abs(args[0])
 		if err != nil {


### PR DESCRIPTION
## Summary
- Fixed issue where command-line arguments weren't properly passed to the frontend
- Changed `GetInitialFiles()` to return a struct instead of multiple values
- Resolves the "read /: is a directory" error when launching via CLI

## Problem
When running `weld file1 file2` from the command line, the application was showing an error and only the first character of each file path was being used (e.g., '/' and 'U' instead of full paths).

## Root Cause
Wails doesn't properly handle Go functions that return multiple values when generating JavaScript bindings. The TypeScript definition was `Promise<string|string>` instead of `Promise<[string, string]>`, causing the frontend to incorrectly destructure what it thought was an array but was actually a string.

## Solution
Changed `GetInitialFiles()` to return a struct (`InitialFiles`) with `LeftFile` and `RightFile` fields. This ensures Wails properly serializes the data as a JSON object that the frontend can correctly access.

## Test Plan
- [x] Build application with `wails build`
- [x] Copy to /Applications/
- [x] Test CLI: `weld ~/.config/nix/flake.nix ~/dotfiles/nix/.config/nix/flake.nix`
- [x] Verify files load and compare correctly
- [x] All backend tests pass
- [x] All frontend tests pass