### PR TITLE
fix: default file selector to home directory

### DIFF
--- a/app.go
+++ b/app.go
@@ -109,20 +109,11 @@ func (a *App) GetInitialFiles() InitialFiles {
 // SelectFile opens a file dialog and returns the selected file path
 func (a *App) SelectFile() (string, error) {
 
-	// Use the sample files directory for testing, relative to current working directory
-	// This works regardless of the user's home directory path
-	var defaultDir string
-	cwd, err := os.Getwd()
+	// Default to user's home directory
+	defaultDir, err := os.UserHomeDir()
 	if err != nil {
-		// Fallback to user's home directory
-		homeDir, homeErr := os.UserHomeDir()
-		if homeErr != nil {
-			defaultDir = ""
-		} else {
-			defaultDir = homeDir
-		}
-	} else {
-		defaultDir = filepath.Join(cwd, "resources", "sample-files", "supported-types")
+		// If we can't get home directory, use empty string (system default)
+		defaultDir = ""
 	}
 
 	file, err := runtime.OpenFileDialog(a.ctx, runtime.OpenDialogOptions{


### PR DESCRIPTION
## Summary
- Changed default file selector path from development-specific path to user's home directory
- Fixes issue where production builds would try to open a non-existent path

## Problem
The file selector was defaulting to `resources/sample-files/supported-types` relative to the current working directory, which only exists in development environments. This path would not exist for end users.

## Solution
Changed to default to the user's home directory using `os.UserHomeDir()`, with a fallback to empty string (system default) if the home directory cannot be determined.

## Test Plan
- [x] All backend tests pass
- [x] Manually tested file selector opens to home directory