### PR TITLE
feat: add ARM64 builds for all platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,15 +14,29 @@ jobs:
     strategy:
       matrix:
         include:
+          # Linux builds
           - os: ubuntu-latest
             platform: linux
             arch: amd64
+          - os: ubuntu-latest
+            platform: linux
+            arch: arm64
+          
+          # Windows builds
           - os: windows-latest
             platform: windows
             arch: amd64
+          - os: windows-latest
+            platform: windows
+            arch: arm64
+          
+          # macOS builds (separate architectures instead of universal)
           - os: macos-latest
             platform: darwin
-            arch: universal
+            arch: amd64
+          - os: macos-latest
+            platform: darwin
+            arch: arm64
     
     runs-on: ${{ matrix.os }}
     
@@ -50,6 +64,12 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
+        
+        # Install cross-compilation tools for ARM64
+        if [ "${{ matrix.arch }}" = "arm64" ]; then
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+        fi
+        
         # Create symlink for webkit2gtk-4.0 pointing to 4.1
         sudo ln -s /usr/lib/x86_64-linux-gnu/pkgconfig/webkit2gtk-4.1.pc /usr/lib/x86_64-linux-gnu/pkgconfig/webkit2gtk-4.0.pc || true
     
@@ -60,12 +80,20 @@ jobs:
     # Build for production
     - name: Build Weld
       run: |
-        if [ "${{ matrix.os }}" = "macos-latest" ]; then
-          # Use Makefile for macOS to include CLI script
-          make build
-        else
-          wails build -platform ${{ matrix.platform }}/${{ matrix.arch }} -clean
+        # For cross-compilation support
+        if [ "${{ matrix.platform }}" = "linux" ] && [ "${{ matrix.arch }}" = "arm64" ]; then
+          export GOARCH=arm64
+          export CGO_ENABLED=1
+          export CC=aarch64-linux-gnu-gcc
+          export CXX=aarch64-linux-gnu-g++
+        elif [ "${{ matrix.platform }}" = "windows" ] && [ "${{ matrix.arch }}" = "arm64" ]; then
+          export GOARCH=arm64
+        elif [ "${{ matrix.platform }}" = "darwin" ]; then
+          # macOS can build for both architectures natively
+          export GOARCH=${{ matrix.arch }}
         fi
+        
+        wails build -platform ${{ matrix.platform }}/${{ matrix.arch }} -clean
       shell: bash
     
     # Ad-hoc sign macOS app to prevent "damaged app" error


### PR DESCRIPTION
## Summary
- Adds ARM64 builds for Linux and Windows
- Splits macOS universal binary into separate AMD64 and ARM64 builds
- All 6 platform/architecture combinations now build in parallel

## Changes
- **Linux**: Now builds for both AMD64 and ARM64
- **Windows**: Now builds for both AMD64 and ARM64  
- **macOS**: Changed from universal binary to separate AMD64 and ARM64 builds

## Benefits
1. **Native ARM support** - Users on ARM devices (Apple Silicon Macs, ARM Linux VMs, Windows on ARM) get native binaries
2. **Smaller downloads** - macOS users download ~half the size (one architecture instead of both)
3. **Better performance** - No emulation layer needed on ARM devices
4. **Future-proofing** - ARM adoption is growing across all platforms

## Technical Details
- Uses cross-compilation for Linux ARM64 (`gcc-aarch64-linux-gnu`)
- Windows ARM64 uses Go's built-in cross-compilation
- macOS builds natively for each architecture
- All builds run in parallel for faster releases

## Testing
- [ ] Linux AMD64 build works (existing)
- [ ] Linux ARM64 build works (new)
- [ ] Windows AMD64 build works (existing)
- [ ] Windows ARM64 build works (new)
- [ ] macOS AMD64 build works (changed)
- [ ] macOS ARM64 build works (changed)

## Release Artifacts
After this change, releases will include:
- `weld-linux-amd64.tar.gz`
- `weld-linux-arm64.tar.gz` (new)
- `weld-windows-amd64.zip`
- `weld-windows-arm64.zip` (new)
- `weld-darwin-amd64.zip` (was part of universal)
- `weld-darwin-arm64.zip` (was part of universal)