### PR TITLE
fix: enable copy menu items on initial diff load

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -470,6 +470,18 @@ async function compareBothFiles(
 				const currentIndex = get(diffStore).currentChunkIndex;
 				if (chunks.length > 0 && currentIndex === -1) {
 					diffStore.setCurrentChunkIndex(0);
+
+					// Update copy menu items for the first diff
+					const highlightedDiffResult = get(diffStore).highlightedDiff;
+					if (
+						highlightedDiffResult &&
+						highlightedDiffResult.lines[chunks[0].startIndex]
+					) {
+						UpdateCopyMenuItems(
+							highlightedDiffResult.lines[chunks[0].startIndex].type,
+						);
+					}
+
 					// Scroll to first diff after a delay
 					setTimeout(() => {
 						if (diffViewerComponent && chunks[0]) {


### PR DESCRIPTION
## Summary
- Fixed bug where Copy to Left/Right menu items were disabled when first loading a diff
- Added explicit menu update when auto-navigating to the first diff after comparison

## Problem
When a diff was first loaded, the Copy menu items remained disabled even though the first diff was automatically selected. This happened because the reactive statement that updates menu items wasn't triggered during the initial navigation.

## Solution
Added an explicit call to `UpdateCopyMenuItems` when auto-navigating to the first diff after file comparison completes. This ensures the menu state correctly reflects the selected diff type.

## Test plan
- [x] Load a diff and verify Copy menu items are enabled immediately
- [x] Navigate between diffs and verify menu items remain properly enabled
- [x] All existing tests pass