### PR TITLE
fix: remove File > Quit on macOS

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,10 +55,14 @@ func BuildMenu(app *App) *menu.Menu {
 	app.SetSaveAllMenuItem(saveAllItem)
 	saveAllItem.Disabled = true
 
-	fileMenu.AddSeparator()
-	fileMenu.AddText("Quit", keys.CmdOrCtrl("q"), func(_ *menu.CallbackData) {
-		runtime.Quit(app.ctx)
-	})
+	// Only add Quit to File menu on non-macOS platforms
+	// macOS has Quit in the application menu (Weld > Quit Weld)
+	if goruntime.GOOS != "darwin" {
+		fileMenu.AddSeparator()
+		fileMenu.AddText("Quit", keys.CmdOrCtrl("q"), func(_ *menu.CallbackData) {
+			runtime.Quit(app.ctx)
+		})
+	}
 
 	// Edit menu - custom implementation to add undo
 	editMenu := appMenu.AddSubmenu("Edit")


### PR DESCRIPTION
## Summary
- Removed "Quit" from File menu on macOS only
- Follows macOS Human Interface Guidelines

## Details
On macOS, the standard pattern is to have Quit in the application menu (Weld > Quit Weld), not in the File menu. This change conditionally removes the redundant File > Quit menu item on macOS while keeping it on Windows and Linux where it's expected.

## Test plan
- [x] On macOS: Verify File menu no longer has Quit option
- [x] On macOS: Verify Weld > Quit Weld still works
- [x] On Windows/Linux: Verify File > Quit is still present